### PR TITLE
Fix: 環境変数を用いてログパスを共有し通信ログ表示問題を解決

### DIFF
--- a/communication_log_window.py
+++ b/communication_log_window.py
@@ -1,5 +1,6 @@
 import customtkinter
 import tkinter as tk # messagebox のため
+import os # ファイル存在確認のため
 from communication_logger import CommunicationLogger
 
 class CommunicationLogWindow(customtkinter.CTkToplevel):
@@ -10,110 +11,141 @@ class CommunicationLogWindow(customtkinter.CTkToplevel):
 
         self.logger = CommunicationLogger() # ロガーのインスタンスを取得
 
-        # ウィンドウを閉じるときの処理
         self.protocol("WM_DELETE_WINDOW", self.on_closing)
 
-        # --- UI要素の作成 ---
         main_frame = customtkinter.CTkFrame(self)
         main_frame.pack(fill="both", expand=True, padx=10, pady=10)
 
-        # ボタンフレーム
         button_frame = customtkinter.CTkFrame(main_frame, fg_color="transparent")
         button_frame.pack(fill="x", pady=(0, 10))
 
         self.refresh_button = customtkinter.CTkButton(button_frame, text="更新", command=self.refresh_logs)
         self.refresh_button.pack(side="left", padx=(0, 5))
 
-        self.save_button = customtkinter.CTkButton(button_frame, text="ログをファイルに保存", command=self.save_logs)
+        self.save_button = customtkinter.CTkButton(button_frame, text="現在の表示内容をファイルに保存 (スナップショット)", command=self.save_snapshot_logs)
         self.save_button.pack(side="left", padx=5)
 
-        self.clear_button = customtkinter.CTkButton(button_frame, text="表示ログをクリア (メモリ)", command=self.clear_displayed_logs)
-        self.clear_button.pack(side="left", padx=5)
+        self.clear_memory_button = customtkinter.CTkButton(button_frame, text="メモリ上のログをクリア", command=self.clear_memory_logs)
+        self.clear_memory_button.pack(side="left", padx=5)
 
-        # ログ表示エリア (CTkTextboxを使用)
-        self.log_display_textbox = customtkinter.CTkTextbox(main_frame, wrap="word", state="disabled", font=("Yu Gothic UI", 12)) # 適切なフォントを指定
+        # セッションログファイルパス表示ラベル
+        self.session_file_label = customtkinter.CTkLabel(button_frame, text="セッションログ: 未定", font=("Yu Gothic UI", 10), anchor="w")
+        self.session_file_label.pack(side="left", padx=10, fill="x", expand=True)
+
+
+        self.log_display_textbox = customtkinter.CTkTextbox(main_frame, wrap="word", state="disabled", font=("Yu Gothic UI", 12))
         self.log_display_textbox.pack(fill="both", expand=True)
 
         self.refresh_logs() # 初期表示
 
     def refresh_logs(self):
-        """ログ表示を更新する"""
-        self.log_display_textbox.configure(state="normal") # テキストを編集可能に
-        self.log_display_textbox.delete("1.0", "end") # 現在の表示をクリア
+        """セッションログファイルからログを読み込み表示を更新する"""
+        self.log_display_textbox.configure(state="normal")
+        self.log_display_textbox.delete("1.0", "end")
 
-        logs = self.logger.get_logs()
-        if not logs:
-            self.log_display_textbox.insert("end", "ログエントリはありません。\n")
+        session_log_path = self.logger.get_session_log_filepath()
+
+        if session_log_path and os.path.exists(session_log_path):
+            try:
+                # セッションログファイルパスをラベルに表示
+                self.session_file_label.configure(text=f"記録中: {os.path.basename(session_log_path)}")
+                with open(session_log_path, "r", encoding="utf-8") as f:
+                    log_content = f.read()
+                if log_content:
+                    # 新しいログが上に来るようにファイルの内容を逆順にするのは大変なので、
+                    # ファイルに記録された順（古いものが上）で表示する。
+                    # もし逆順表示が必要なら、CommunicationLogger側でファイル書き込み順を工夫するか、
+                    # ここで読み込んだ後に行ごとに処理して逆順にする必要がある。
+                    # シンプルにするため、ここではファイル通りの順で表示する。
+                    self.log_display_textbox.insert("end", log_content)
+                else:
+                    self.log_display_textbox.insert("end", f"セッションログファイル '{os.path.basename(session_log_path)}' は空です。\n")
+            except Exception as e:
+                self.log_display_textbox.insert("end", f"セッションログファイル '{os.path.basename(session_log_path)}' の読み込みエラー: {e}\n")
+                tk.messagebox.showerror("読込エラー", f"ログファイルの読み込みに失敗しました:\n{session_log_path}\nエラー: {e}", parent=self)
         else:
-            for entry in reversed(logs): # 新しいログが上に来るように逆順で表示
-                self.log_display_textbox.insert("end", f"Timestamp: {entry['timestamp']}\n")
-                self.log_display_textbox.insert("end", f"Direction: {entry['direction']}\n")
-                self.log_display_textbox.insert("end", f"Function Type: {entry['function_type']}\n")
-                self.log_display_textbox.insert("end", f"Body:\n{entry['text_body']}\n")
-                self.log_display_textbox.insert("end", "-" * 40 + "\n\n")
+            no_log_message = "セッションログファイルが見つかりません。"
+            if session_log_path:
+                 no_log_message = f"セッションログファイル '{os.path.basename(session_log_path)}' が見つかりません。\nアプリケーションがログを記録し始めると作成されます。"
+                 self.session_file_label.configure(text=f"記録待機中: {os.path.basename(session_log_path)}")
+            else:
+                 self.session_file_label.configure(text="セッションログ: パス未設定")
 
-        self.log_display_textbox.configure(state="disabled") # テキストを読み取り専用に
+            self.log_display_textbox.insert("end", no_log_message + "\n")
 
-    def save_logs(self):
-        """ログをファイルに保存する"""
-        self.logger.save_logs_to_file(parent_window=self) # CommunicationLoggerの保存メソッドを呼び出す
+        self.log_display_textbox.configure(state="disabled")
 
-    def clear_displayed_logs(self):
-        """表示されているログ（メモリ上のログ）をクリアする"""
-        # customtkinter に標準的な Yes/No ダイアログがないため、tkinter.messagebox を使うか、
-        # 自作するか、CTkInputDialog で代用する。ここではCTkInputDialogで簡易的に行う。
-        dialog = customtkinter.CTkInputDialog(text="メモリ上の全ての通信ログをクリアしますか？\nこの操作は元に戻せません。\nよろしければ「はい」と入力してください。", title="ログクリア確認")
+    def save_snapshot_logs(self):
+        """現在メモリに読み込まれているログのスナップショットをファイルに保存する"""
+        # CommunicationLoggerのsave_logs_to_fileはメモリ上のログを保存する
+        # refresh_logsはファイルから読み込むので、メモリ上のログと表示が一致しない可能性がある。
+        # ここでは「表示されている内容」ではなく「現在のメモリ上のログ」を保存する。
+        # もし「表示されている内容」を保存したいなら、テキストボックスの内容を取得して保存する。
+        # プランでは save_logs_to_file を呼び出すことになっているので、メモリログを保存する。
+        self.logger.save_logs_to_file(parent_window=self)
+
+    def clear_memory_logs(self):
+        """メモリ上のログのみをクリアする。表示は次の「更新」まで変わらない。"""
+        # ボタンのテキストを「メモリ上のログをクリア」に変更したため、確認ダイアログの文言も調整
+        dialog = customtkinter.CTkInputDialog(
+            text="メモリ上の通信ログのみをクリアしますか？\n記録中のセッションログファイルには影響しません。\nスナップショット保存の対象がクリアされます。\nよろしければ「はい」と入力してください。",
+            title="メモリログクリア確認"
+        )
         user_input = dialog.get_input()
-        if user_input and user_input.lower() == "はい":
-             self.logger.clear_logs()
-             self.refresh_logs()
-        elif user_input is not None: # 何か入力したが「はい」ではなかった場合
-            tk.messagebox.showwarning("クリア中止", "入力が「はい」と一致しなかったため、ログはクリアされませんでした。", parent=self)
 
+        if user_input and user_input.lower() == "はい":
+            self.logger.clear_logs() # メモリ上のログをクリア
+            # self.refresh_logs() # プランでは表示更新だが、ここではクリアしたことを明確にするため更新しない。
+            # 更新ボタンでユーザーが明示的にファイルから再読み込みする。
+            # または、クリアした旨をメッセージで表示する。
+            tk.messagebox.showinfo("クリア完了", "メモリ上のログはクリアされました。\n表示を更新するには「更新」ボタンを押してください。\nセッションログファイルは影響を受けていません。", parent=self)
+            # 表示されている内容は古いままなので、ユーザーに混乱を与えないように
+            # テキストボックスを一時的に「メモリはクリアされました」などにしても良いが、
+            # 次の更新で元に戻る。
+        elif user_input is not None:
+            tk.messagebox.showwarning("クリア中止", "入力が「はい」と一致しなかったため、メモリ上のログはクリアされませんでした。", parent=self)
 
     def on_closing(self):
-        """ウィンドウが閉じられるときの処理"""
-        # self.withdraw() # ウィンドウを隠すだけならこちら
-        self.destroy() # ウィンドウを破棄する
+        self.destroy()
 
 if __name__ == '__main__':
-    # このウィンドウを単体でテストするためのコード
     app = customtkinter.CTk()
-    customtkinter.set_appearance_mode("System") # or "Light", "Dark"
-    customtkinter.set_default_color_theme("blue") # or "green", "dark-blue"
+    customtkinter.set_appearance_mode("System")
+    customtkinter.set_default_color_theme("blue")
     app.title("Test App for Communication Log")
-    app.geometry("400x300")
+    # app.geometry("400x300") # Window自体のサイズはWindowクラスで設定
 
-    # ダミーログの追加 (テスト用)
-    logger_instance = CommunicationLogger()
-    logger_instance.add_log("sent", "text_generation", "これはテスト用の送信プロンプトです。\n複数行のテストも兼ねています。")
-    logger_instance.add_log("received", "text_generation", "これはテスト用のAIレスポンスです。")
-    for i in range(5): # 少し多めにログを追加
-        logger_instance.add_log("sent", "voice_synthesis", f"テスト用音声合成リクエスト {i+1}。長めの文章も入れてみましょう。祇園精舎の鐘の声、諸行無常の響きあり。")
-        logger_instance.add_log("received", "voice_synthesis", f"音声合成結果 {i+1} (これはダミーです。通常、音声合成のレスポンスBodyは記録しませんが、テストとして)")
+    # テスト用のログディレクトリとファイルを作成
+    test_log_dir = "test_comm_log_window_logs"
+    if not os.path.exists(test_log_dir):
+        os.makedirs(test_log_dir)
 
+    # CommunicationLogger のインスタンスを作成し、テスト用ディレクトリを指定
+    # これにより、セッションログファイルが test_log_dir 内に作成される
+    logger_instance = CommunicationLogger(log_dir=test_log_dir)
 
-    # グローバル変数やクラス変数としてウィンドウインスタンスを保持しないようにする
-    # log_window_instance = None
+    # ダミーログを追加 (これによりセッションログファイルにも書き込まれる)
+    logger_instance.add_log("sent", "test_init", "初期化テスト用の送信プロンプト。")
+    logger_instance.add_log("received", "test_init", "初期化テスト用のAIレスポンス。")
+
 
     def open_log_window():
-        # nonlocal log_window_instance # nonlocalは不要
-        # if log_window_instance is None or not log_window_instance.winfo_exists():
-        #     log_window_instance = CommunicationLogWindow(app)
-        # else:
-        #     log_window_instance.deiconify()
-        #     log_window_instance.lift()
-        #     log_window_instance.focus()
-        #     if hasattr(log_window_instance, 'refresh_logs'):
-        #         log_window_instance.refresh_logs()
-
-        # シンプルに毎回新しいウィンドウを開くか、launcher.py と同様の管理をする
-        # ここではテストなのでシンプルに毎回開く
         new_log_win = CommunicationLogWindow(app)
-        # new_log_win.grab_set() # モーダルにする場合はコメント解除
-
+        # new_log_win.grab_set()
 
     open_button = customtkinter.CTkButton(app, text="ログウィンドウを開く", command=open_log_window)
-    open_button.pack(pady=20)
+    open_button.pack(pady=20, padx=20)
 
+    # テスト終了後にテストディレクトリを削除するための処理
+    def cleanup_test_dir():
+        import shutil
+        if os.path.exists(test_log_dir):
+            try:
+                shutil.rmtree(test_log_dir)
+                print(f"Cleaned up test directory: {test_log_dir}")
+            except Exception as e:
+                print(f"Error cleaning up test directory {test_log_dir}: {e}")
+        app.destroy() # アプリケーション終了
+
+    app.protocol("WM_DELETE_WINDOW", cleanup_test_dir)
     app.mainloop()

--- a/communication_logger.py
+++ b/communication_logger.py
@@ -4,38 +4,105 @@ from tkinter import filedialog, messagebox # messagebox用にtkinterをインポ
 
 class CommunicationLogger:
     _instance = None
+    _session_log_filepath = None
+    _log_dir = None # 初期値はNoneとし、__new__で決定する
+
+    # 環境変数名
+    ENV_VAR_LOG_DIR = 'GLOBAL_LOG_DIR_PATH'
+    ENV_VAR_SESSION_LOG = 'GLOBAL_SESSION_LOG_PATH'
+
+    DEFAULT_LOG_DIR = "communication_logs"
 
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
-            cls._instance = super(CommunicationLogger, cls).__new__(cls, *args, **kwargs)
+            cls._instance = super(CommunicationLogger, cls).__new__(cls)
             cls._instance._initialized = False
+
+            # 1. ログディレクトリ (_log_dir) の決定
+            # 優先順位: 環境変数 > コンストラクタ引数 > デフォルト値
+            env_log_dir = os.getenv(cls.ENV_VAR_LOG_DIR)
+            arg_log_dir = kwargs.get('log_dir', args[0] if len(args) > 0 and args[0] is not None else None)
+
+            if env_log_dir:
+                CommunicationLogger._log_dir = os.path.abspath(env_log_dir)
+                # print(f"Logger (new): Using log_dir from ENV: {CommunicationLogger._log_dir}")
+            elif arg_log_dir:
+                CommunicationLogger._log_dir = os.path.abspath(arg_log_dir)
+                # print(f"Logger (new): Using log_dir from ARG: {CommunicationLogger._log_dir}")
+            else:
+                CommunicationLogger._log_dir = os.path.abspath(cls.DEFAULT_LOG_DIR)
+                # print(f"Logger (new): Using log_dir DEFAULT: {CommunicationLogger._log_dir}")
+
+            # ログディレクトリの作成 (存在しない場合)
+            if not os.path.exists(CommunicationLogger._log_dir):
+                try:
+                    os.makedirs(CommunicationLogger._log_dir)
+                    print(f"Logger (new): Log directory created: {CommunicationLogger._log_dir}")
+                except Exception as e:
+                    print(f"Logger (new): Error creating log directory {CommunicationLogger._log_dir}: {e}")
+                    # フォールバック (カレントディレクトリのcommunication_logs)
+                    CommunicationLogger._log_dir = os.path.abspath(cls.DEFAULT_LOG_DIR)
+                    if not os.path.exists(CommunicationLogger._log_dir):
+                        try: os.makedirs(CommunicationLogger._log_dir)
+                        except: pass # さらに失敗する場合は仕方ない
+                    print(f"Logger (new): Falling back to log_dir: {CommunicationLogger._log_dir}")
+
+            # 2. セッションログファイルパス (_session_log_filepath) の決定
+            # 優先順位: 環境変数 > （環境変数がなければ）新規生成
+            env_session_log = os.getenv(cls.ENV_VAR_SESSION_LOG)
+            if env_session_log:
+                CommunicationLogger._session_log_filepath = os.path.abspath(env_session_log)
+                # print(f"Logger (new): Using session_log from ENV: {CommunicationLogger._session_log_filepath}")
+                # 環境変数で指定された場合、それが属するディレクトリが _log_dir と一致するか確認（任意）
+                # ここでは、環境変数で指定されたパスをそのまま信頼する
+                # ただし、そのディレクトリが存在しない場合は作成を試みる
+                _s_log_dir = os.path.dirname(CommunicationLogger._session_log_filepath)
+                if not os.path.exists(_s_log_dir) :
+                    try: os.makedirs(_s_log_dir); print(f"Logger (new): Created directory for ENV session_log: {_s_log_dir}")
+                    except Exception as e_mkdir: print(f"Logger (new): Failed to create dir for ENV session_log {_s_log_dir}: {e_mkdir}")
+
+            else: # 環境変数がない場合、新規生成
+                timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+                filename = f"session_log_{timestamp}.txt"
+                CommunicationLogger._session_log_filepath = os.path.join(CommunicationLogger._log_dir, filename)
+                # print(f"Logger (new): Generated new session_log: {CommunicationLogger._session_log_filepath}")
+                # 新規生成時はヘッダーを書き込む
+                try:
+                    with open(CommunicationLogger._session_log_filepath, "a", encoding="utf-8") as f:
+                        f.write(f"--- Session Log Started (New): {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} ---\n\n")
+                except Exception as e:
+                    print(f"Logger (new): Error initializing new session log file '{CommunicationLogger._session_log_filepath}': {e}")
+
         return cls._instance
 
-    def __init__(self, log_dir="communication_logs"):
+    def __init__(self, log_dir=None): # log_dir引数は__new__で処理されるため、ここではほぼ参照不要
         if self._initialized:
             return
         self.log_entries = []
-        self.log_dir = log_dir
-        # ログディレクトリの存在確認と作成
-        if not os.path.exists(self.log_dir):
+
+        # __new__でパスが決定され、ディレクトリも作成されているはず
+        # もし_session_log_filepathがNoneのままなら、何かがおかしい（基本的には起こらない想定）
+        if CommunicationLogger._session_log_filepath is None:
+            print("Logger (init): CRITICAL - _session_log_filepath is None after __new__.")
+            # 緊急避難的にデフォルトパスを再生成するなどの処理も考えられるが、設計上は__new__で解決するべき
+            # ここでは、エラーのままとする
+
+        # 環境変数でパスが指定され、かつファイルがまだ存在しない場合にヘッダーを書き込む
+        # (新規生成の場合は__new__で既に書き込まれている)
+        if os.getenv(self.ENV_VAR_SESSION_LOG) and \
+           CommunicationLogger._session_log_filepath and \
+           not os.path.exists(CommunicationLogger._session_log_filepath):
+            # print(f"Logger (init): Session log from ENV does not exist, creating: {CommunicationLogger._session_log_filepath}")
             try:
-                os.makedirs(self.log_dir)
-                print(f"Log directory created: {os.path.abspath(self.log_dir)}")
+                with open(CommunicationLogger._session_log_filepath, "a", encoding="utf-8") as f:
+                    f.write(f"--- Session Log Started (ENV, Created): {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} ---\n\n")
             except Exception as e:
-                print(f"Error creating log directory {self.log_dir}: {e}")
-                # カレントディレクトリをフォールバックとして使用
-                self.log_dir = "."
-                print(f"Falling back to current directory for logs: {os.path.abspath(self.log_dir)}")
+                print(f"Logger (init): Error creating session log file from ENV '{CommunicationLogger._session_log_filepath}': {e}")
 
         self._initialized = True
 
+
     def add_log(self, direction, function_type, text_body):
-        """
-        Adds a new log entry.
-        :param direction: "sent" or "received"
-        :param function_type: "text_generation" or "voice_synthesis"
-        :param text_body: The plain text body of the communication.
-        """
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         log_entry = {
             "timestamp": timestamp,
@@ -44,88 +111,183 @@ class CommunicationLogger:
             "text_body": text_body
         }
         self.log_entries.append(log_entry)
-        # print(f"Log added: {direction}, {function_type}, {len(text_body)} chars") # Optional: for debugging
+
+        if CommunicationLogger._session_log_filepath:
+            try:
+                with open(CommunicationLogger._session_log_filepath, "a", encoding="utf-8") as f:
+                    f.write(f"Timestamp: {log_entry['timestamp']}\n")
+                    f.write(f"Direction: {log_entry['direction']}\n")
+                    f.write(f"Function Type: {log_entry['function_type']}\n")
+                    f.write(f"Body:\n{log_entry['text_body']}\n")
+                    f.write("-" * 40 + "\n\n")
+            except Exception as e:
+                print(f"Error writing to session log file '{CommunicationLogger._session_log_filepath}': {e}")
+        else:
+            print("Logger (add_log): Error - _session_log_filepath is not set. Cannot write to file.")
+
 
     def get_logs(self):
-        """
-        Returns all recorded log entries.
-        """
         return self.log_entries
 
+    def get_session_log_filepath(self):
+        return CommunicationLogger._session_log_filepath
+
+    def get_log_dir(self): # ログディレクトリ取得用メソッド
+        return CommunicationLogger._log_dir
+
     def clear_logs(self):
-        """
-        Clears all recorded log entries from memory.
-        """
         self.log_entries = []
-        # print("Logs cleared from memory.") # Optional: for debugging
 
     def save_logs_to_file(self, parent_window=None):
-        """
-        Saves all recorded log entries to a file.
-        The filename includes the current timestamp.
-        :param parent_window: Parent window for messagebox (optional).
-        """
         if not self.log_entries:
-            messagebox.showinfo("保存情報", "保存するログがありません。", parent=parent_window)
+            messagebox.showinfo("保存情報", "メモリ内に保存するログがありません。", parent=parent_window)
             return
 
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        filename = f"communication_log_{timestamp}.txt"
+        initial_dir = CommunicationLogger._log_dir \
+            if CommunicationLogger._log_dir and os.path.isdir(CommunicationLogger._log_dir) \
+            else os.path.abspath(".")
 
-        # ログディレクトリが絶対パスでない場合は、カレントディレクトリからの相対パスと解釈される
-        # ここでは __init__ で設定された self.log_dir をそのまま使う
-        filepath = os.path.join(self.log_dir, filename)
+        initial_timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        initial_filename = f"communication_snapshot_{initial_timestamp}.txt"
+
+        filepath = filedialog.asksaveasfilename(
+            parent=parent_window,
+            title="ログスナップショットを名前を付けて保存",
+            initialdir=initial_dir,
+            initialfile=initial_filename,
+            defaultextension=".txt",
+            filetypes=[("Text files", "*.txt"), ("All files", "*.*")]
+        )
+
+        if not filepath:
+            return
 
         try:
             with open(filepath, "w", encoding="utf-8") as f:
+                f.write(f"--- Log Snapshot Taken: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} ---\n")
+                f.write(f"--- Based on in-memory logs at the time of saving. ---\n\n")
                 for entry in self.log_entries:
                     f.write(f"Timestamp: {entry['timestamp']}\n")
                     f.write(f"Direction: {entry['direction']}\n")
                     f.write(f"Function Type: {entry['function_type']}\n")
                     f.write(f"Body:\n{entry['text_body']}\n")
-                    f.write("-" * 40 + "\n")
-            messagebox.showinfo("保存完了", f"ログを {os.path.abspath(filepath)} に保存しました。", parent=parent_window)
-            # print(f"Logs saved to: {os.path.abspath(filepath)}") # Optional: for debugging
+                    f.write("-" * 40 + "\n\n")
+            messagebox.showinfo("保存完了", f"ログスナップショットを {os.path.abspath(filepath)} に保存しました。", parent=parent_window)
         except Exception as e:
-            messagebox.showerror("保存エラー", f"ログの保存中にエラーが発生しました: {e}", parent=parent_window)
-            # print(f"Error saving logs: {e}") # Optional: for debugging
+            messagebox.showerror("保存エラー", f"ログスナップショットの保存中にエラーが発生しました: {e}", parent=parent_window)
 
 if __name__ == "__main__":
-    # テスト用のコード
-    logger = CommunicationLogger() # 初回インスタンス化
-    logger_same = CommunicationLogger() # 同じインスタンスのはず
+    import shutil
 
-    print(f"Is logger the same instance as logger_same? {logger is logger_same}")
+    def reset_env_vars():
+        if CommunicationLogger.ENV_VAR_LOG_DIR in os.environ: del os.environ[CommunicationLogger.ENV_VAR_LOG_DIR]
+        if CommunicationLogger.ENV_VAR_SESSION_LOG in os.environ: del os.environ[CommunicationLogger.ENV_VAR_SESSION_LOG]
+        CommunicationLogger._instance = None # シングルトンリセット
+        CommunicationLogger._log_dir = None
+        CommunicationLogger._session_log_filepath = None
 
-    logger.add_log("sent", "text_generation", "ユーザーからのプロンプトです。")
-    logger.add_log("received", "text_generation", "AIからのレスポンスです。")
-    logger.add_log("sent", "voice_synthesis", "読み上げるテキストです。")
 
-    all_logs = logger.get_logs()
-    print(f"\n--- Recorded Logs ({len(all_logs)}) ---")
-    for log_item in all_logs:
-        print(f"  Timestamp: {log_item['timestamp']}")
-        print(f"  Direction: {log_item['direction']}")
-        print(f"  Type: {log_item['function_type']}")
-        print(f"  Body: {log_item['text_body'][:50]}...") # Displaying first 50 chars
-        print("-" * 20)
+    print("--- Test Suite for CommunicationLogger ---")
 
-    # messageboxのテストのためにtkinterのルートウィンドウを一時的に作成
-    # import tkinter
-    # test_root = tkinter.Tk()
-    # test_root.withdraw() # 表示はしない
+    # Test Case 1: No ENV VARS, no args (defaults)
+    reset_env_vars()
+    test_dir_1 = os.path.abspath(CommunicationLogger.DEFAULT_LOG_DIR)
+    if os.path.exists(test_dir_1): shutil.rmtree(test_dir_1)
+    print("\n[Test 1] Defaults (no ENV, no Args)")
+    logger1 = CommunicationLogger()
+    assert logger1.get_log_dir() == test_dir_1, f"Test 1 LogDir: Expected {test_dir_1}, Got {logger1.get_log_dir()}"
+    assert logger1.get_session_log_filepath().startswith(test_dir_1), "Test 1 SessionFile path mismatch"
+    assert os.path.exists(logger1.get_session_log_filepath()), "Test 1 Session file not created"
+    logger1.add_log("t1", "default", "Test 1")
+    if os.path.exists(test_dir_1): shutil.rmtree(test_dir_1)
 
-    # logger.save_logs_to_file(parent_window=test_root)
 
-    # # ファイルが実際に作成されたか確認 (手動)
-    # print(f"\nCheck for log file in: {os.path.abspath(logger.log_dir)}")
+    # Test Case 2: log_dir from argument
+    reset_env_vars()
+    test_dir_2_arg = "test_logs_arg"
+    test_dir_2 = os.path.abspath(test_dir_2_arg)
+    if os.path.exists(test_dir_2): shutil.rmtree(test_dir_2)
+    print(f"\n[Test 2] Log dir from argument ('{test_dir_2_arg}')")
+    logger2 = CommunicationLogger(log_dir=test_dir_2_arg)
+    assert logger2.get_log_dir() == test_dir_2, f"Test 2 LogDir: Expected {test_dir_2}, Got {logger2.get_log_dir()}"
+    assert logger2.get_session_log_filepath().startswith(test_dir_2), "Test 2 SessionFile path mismatch"
+    logger2.add_log("t2", "arg", "Test 2")
+    if os.path.exists(test_dir_2): shutil.rmtree(test_dir_2)
 
-    # logger.clear_logs()
-    # print(f"\nLogs after clearing: {logger.get_logs()}")
 
-    # logger.add_log("sent", "text_generation", "クリア後の新しいログ。")
-    # logger.save_logs_to_file(parent_window=test_root)
-    # print(f"\nCheck for another log file in: {os.path.abspath(logger.log_dir)}")
+    # Test Case 3: log_dir from ENV VAR
+    reset_env_vars()
+    test_dir_3_env = "test_logs_env_dir"
+    os.environ[CommunicationLogger.ENV_VAR_LOG_DIR] = test_dir_3_env
+    test_dir_3 = os.path.abspath(test_dir_3_env)
+    if os.path.exists(test_dir_3): shutil.rmtree(test_dir_3)
+    print(f"\n[Test 3] Log dir from ENV ('{test_dir_3_env}')")
+    logger3 = CommunicationLogger() # No arg, should pick up ENV
+    assert logger3.get_log_dir() == test_dir_3, f"Test 3 LogDir: Expected {test_dir_3}, Got {logger3.get_log_dir()}"
+    assert logger3.get_session_log_filepath().startswith(test_dir_3), "Test 3 SessionFile path mismatch"
+    logger3.add_log("t3", "env_dir", "Test 3")
+    if os.path.exists(test_dir_3): shutil.rmtree(test_dir_3)
 
-    # test_root.destroy() # テストウィンドウを閉じる
-    print("\nCommunicationLogger test finished.")
+
+    # Test Case 4: session_log_filepath from ENV VAR
+    reset_env_vars()
+    test_dir_4_env = "test_logs_env_session_dir" # Separate dir for this test's session file
+    test_session_file_env = os.path.join(test_dir_4_env, "session_from_env.log")
+    os.environ[CommunicationLogger.ENV_VAR_SESSION_LOG] = test_session_file_env
+    # For this test, also set ENV_VAR_LOG_DIR to ensure _log_dir is also derived from ENV if needed, or is consistent
+    os.environ[CommunicationLogger.ENV_VAR_LOG_DIR] = test_dir_4_env
+
+    test_dir_4 = os.path.abspath(test_dir_4_env)
+    if os.path.exists(test_dir_4): shutil.rmtree(test_dir_4) # Clean before test
+    # os.makedirs(test_dir_4, exist_ok=True) # Ensure dir exists for the session file
+
+    print(f"\n[Test 4] Session log from ENV ('{test_session_file_env}')")
+    logger4 = CommunicationLogger()
+    abs_test_session_file_env = os.path.abspath(test_session_file_env)
+    assert logger4.get_session_log_filepath() == abs_test_session_file_env, f"Test 4 SessionFile: Expected {abs_test_session_file_env}, Got {logger4.get_session_log_filepath()}"
+    assert logger4.get_log_dir() == test_dir_4, f"Test 4 LogDir with session ENV: Expected {test_dir_4}, Got {logger4.get_log_dir()}"
+    assert os.path.exists(logger4.get_session_log_filepath()), "Test 4 Session file (from ENV) not created/found"
+    logger4.add_log("t4", "env_session", "Test 4")
+    if os.path.exists(test_dir_4): shutil.rmtree(test_dir_4)
+
+
+    # Test Case 5: ENV VAR for log_dir takes precedence over argument
+    reset_env_vars()
+    test_dir_5_env = "test_logs_env_priority_dir"
+    test_dir_5_arg = "test_logs_arg_ignored_dir"
+    os.environ[CommunicationLogger.ENV_VAR_LOG_DIR] = test_dir_5_env
+    test_dir_5 = os.path.abspath(test_dir_5_env)
+    if os.path.exists(test_dir_5): shutil.rmtree(test_dir_5)
+    if os.path.exists(os.path.abspath(test_dir_5_arg)) : shutil.rmtree(os.path.abspath(test_dir_5_arg))
+
+    print(f"\n[Test 5] ENV log_dir ('{test_dir_5_env}') takes precedence over arg ('{test_dir_5_arg}')")
+    logger5 = CommunicationLogger(log_dir=test_dir_5_arg)
+    assert logger5.get_log_dir() == test_dir_5, f"Test 5 LogDir: Expected ENV {test_dir_5}, Got {logger5.get_log_dir()}"
+    logger5.add_log("t5", "env_priority", "Test 5")
+    if os.path.exists(test_dir_5): shutil.rmtree(test_dir_5)
+    if os.path.exists(os.path.abspath(test_dir_5_arg)) : shutil.rmtree(os.path.abspath(test_dir_5_arg))
+
+
+    # Test Case 6: Singleton behavior (logs accumulate in memory and file)
+    reset_env_vars()
+    test_dir_6 = os.path.abspath("test_singleton_dir")
+    if os.path.exists(test_dir_6): shutil.rmtree(test_dir_6)
+    print("\n[Test 6] Singleton Behavior")
+    logger6a = CommunicationLogger(log_dir="test_singleton_dir")
+    logger6a.add_log("s6", "part1", "Singleton part 1")
+    logger6b = CommunicationLogger() # Should be same instance
+    assert logger6a is logger6b, "Test 6: Not a singleton"
+    logger6b.add_log("s6", "part2", "Singleton part 2")
+    assert len(logger6a.get_logs()) == 2, f"Test 6: Expected 2 logs in memory, got {len(logger6a.get_logs())}"
+
+    # Check file content (simple check for number of entries)
+    if logger6a.get_session_log_filepath() and os.path.exists(logger6a.get_session_log_filepath()):
+        with open(logger6a.get_session_log_filepath(), "r", encoding="utf-8") as f:
+            content = f.read()
+            assert content.count("Timestamp:") == 2 + 1, f"Test 6: Expected 2 log entries in file (+1 for header), found {content.count('Timestamp:')-1}" # +1 for header
+    else:
+        assert False, "Test 6: Session log file not found for content check"
+    if os.path.exists(test_dir_6): shutil.rmtree(test_dir_6)
+
+    reset_env_vars() # Clean up env vars for subsequent runs if any
+    print("\n--- All tests finished ---")


### PR DESCRIPTION
前回修正後も発生していた、異なるプロセスで起動された場合に通信ログが通信詳細画面に表示されない問題を修正しました。

- ランチャー(`launcher.py`)が起動時に`CommunicationLogger`を初期化し、決定されたログディレクトリパスとセッションログファイルパスをそれぞれ環境変数 `GLOBAL_LOG_DIR_PATH` と `GLOBAL_SESSION_LOG_PATH` に設定するように変更しました。
- `CommunicationLogger`が、これらの環境変数を最優先で参照し、ログディレクトリとセッションログファイルパスを決定するように修正しました。環境変数が未設定の場合は、コンストラクタ引数やデフォルト値を用いたフォールバック処理を行います。
- これにより、ランチャーから起動される各サブプロセス (AIチャットウィンドウ、通信詳細ウィンドウなど) が同じログファイルパスを共有し、ログの記録と表示が正しく連携されるようになりました。

この修正により、AIチャット等で発生した通信ログが、通信詳細画面で確実に表示されるようになります。