### PR TITLE
Feat: Implement internationalization for Communication Log Window

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -806,6 +806,27 @@
         "debug.log.ai_chat_test_error": "❌ AI chat test error: {e}",
         "debug.log.local_llm_request_start": "🤖 {char_name}: Sending request to Local LLM ({endpoint_url})...",
         "debug.log.local_llm_call_error": "❌ Local LLM call error ({endpoint_url}): {e}",
-        "debug.log.prefix_log": "[LOG] "
+        "debug.log.prefix_log": "[LOG] ",
+        "communication_log.title": "Communication Details Log",
+        "communication_log.button.refresh": "Refresh",
+        "communication_log.button.save_snapshot": "Save Current Display to File (Snapshot)",
+        "communication_log.button.clear_memory": "Clear In-Memory Logs",
+        "communication_log.session_file_label.default": "Session Log: Undetermined",
+        "communication_log.session_file_label.recording": "Recording: {filename}",
+        "communication_log.log_empty": "Session log file '{filename}' is empty.\n",
+        "communication_log.log_read_error": "Error reading session log file '{filename}': {error}\n",
+        "communication_log.messagebox.read_error.title": "Read Error",
+        "communication_log.messagebox.read_error.message": "Failed to read log file:\n{filepath}\nError: {error}",
+        "communication_log.log_not_found_default": "Session log file not found.",
+        "communication_log.log_not_found_specific": "Session log file '{filename}' not found.\nIt will be created when the application starts logging.",
+        "communication_log.session_file_label.waiting": "Waiting to record: {filename}",
+        "communication_log.session_file_label.path_not_set": "Session Log: Path not set",
+        "communication_log.input_dialog.clear_memory.text": "Clear only in-memory communication logs?\nThis will not affect the active session log file.\nThe target for snapshot saving will be cleared.\nEnter 'yes' to confirm.",
+        "communication_log.input_dialog.clear_memory.title": "Confirm Clear Memory Logs",
+        "communication_log.messagebox.clear_success.title": "Clear Complete",
+        "communication_log.messagebox.clear_success.message": "In-memory logs have been cleared.\nPress 'Refresh' to update the display.\nThe session log file has not been affected.",
+        "communication_log.messagebox.clear_canceled.title": "Clear Canceled",
+        "communication_log.messagebox.clear_canceled.message": "Clearing of in-memory logs was canceled because the input did not match 'yes'.",
+        "common.yes": "yes"
     }
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -807,6 +807,27 @@
         "debug.log.ai_chat_test_error": "❌ AI対話テストエラー: {e}",
         "debug.log.local_llm_request_start": "🤖 {char_name}: ローカルLLM ({endpoint_url}) にリクエスト送信中...",
         "debug.log.local_llm_call_error": "❌ ローカルLLM呼び出しエラー ({endpoint_url}): {e}",
-        "debug.log.prefix_log": "[LOG] "
+        "debug.log.prefix_log": "[LOG] ",
+        "communication_log.title": "通信詳細ログ",
+        "communication_log.button.refresh": "更新",
+        "communication_log.button.save_snapshot": "現在の表示内容をファイルに保存 (スナップショット)",
+        "communication_log.button.clear_memory": "メモリ上のログをクリア",
+        "communication_log.session_file_label.default": "セッションログ: 未定",
+        "communication_log.session_file_label.recording": "記録中: {filename}",
+        "communication_log.log_empty": "セッションログファイル '{filename}' は空です。\n",
+        "communication_log.log_read_error": "セッションログファイル '{filename}' の読み込みエラー: {error}\n",
+        "communication_log.messagebox.read_error.title": "読込エラー",
+        "communication_log.messagebox.read_error.message": "ログファイルの読み込みに失敗しました:\n{filepath}\nエラー: {error}",
+        "communication_log.log_not_found_default": "セッションログファイルが見つかりません。",
+        "communication_log.log_not_found_specific": "セッションログファイル '{filename}' が見つかりません。\nアプリケーションがログを記録し始めると作成されます。",
+        "communication_log.session_file_label.waiting": "記録待機中: {filename}",
+        "communication_log.session_file_label.path_not_set": "セッションログ: パス未設定",
+        "communication_log.input_dialog.clear_memory.text": "メモリ上の通信ログのみをクリアしますか？\n記録中のセッションログファイルには影響しません。\nスナップショット保存の対象がクリアされます。\nよろしければ「はい」と入力してください。",
+        "communication_log.input_dialog.clear_memory.title": "メモリログクリア確認",
+        "communication_log.messagebox.clear_success.title": "クリア完了",
+        "communication_log.messagebox.clear_success.message": "メモリ上のログはクリアされました。\n表示を更新するには「更新」ボタンを押してください。\nセッションログファイルは影響を受けていません。",
+        "communication_log.messagebox.clear_canceled.title": "クリア中止",
+        "communication_log.messagebox.clear_canceled.message": "入力が「はい」と一致しなかったため、メモリ上のログはクリアされませんでした。",
+        "common.yes": "はい"
     }
 }


### PR DESCRIPTION
- Added new translation keys for UI elements and messages in `communication_log_window.py` to `locales/en.json` and `locales/ja.json`.
- Added a common translation key `common.yes` for confirmation dialogs.
- Modified `communication_log_window.py` to use the translation function for all user-facing strings.
- Updated the confirmation logic in `clear_memory_logs` to use the translated `common.yes` key for language-agnostic comparison.