### PR TITLE
Debug: Use subprocess.Popen directly to test dummy server launch

### DIFF
--- a/mcp_client.py
+++ b/mcp_client.py
@@ -1,375 +1,190 @@
 import asyncio
 import json
-from pathlib import Path # Pathをインポート
+import subprocess # subprocess をインポート
+from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple, Callable
 
-# MCP SDK のインポート
+# MCP SDK のインポート (ClientSessionなどはsubprocess直接利用時は使わないが、型ヒント用に残す場合もある)
 try:
-    from mcp.client.session import ClientSession
-    from mcp.client.stdio import stdio_client, StdioServerParameters
-    from mcp.types import Tool, Resource # MCP SDKが提供する型 (仮定、実際の型名に合わせる)
-    # 例: from mcp.common.types import ToolDefinition, ResourceDefinition, ToolCallResult
-    # 上記は仮なので、実際のSDKの型定義を探して使う
-    # Tool, Resource, ToolCallResult はDict[str,Any]で一旦代用も可
-    print("Successfully imported MCP SDK classes from 'mcp' package.")
+    from mcp.client.session import ClientSession # 今回のテストでは直接は使わない
+    from mcp.client.stdio import StdioServerParameters # 設定読み込みには使う
+    # from mcp.types import Tool, Resource # 必要なら
+    print("Successfully imported MCP SDK classes from 'mcp' package (for type hints or parameters).")
     MCP_SDK_AVAILABLE = True
 except ImportError as e_mcp:
     MCP_SDK_AVAILABLE = False
-    # SDKがない場合は動作しないので、エラーを出すか、限定的なモックにする。
-    # 今回は、SDKが必須であるという前提で進めるため、エラーをraiseしてもよいが、
-    # 既存の動作を維持するため、一旦モックを残すが、いずれ削除する。
-    print(f"CRITICAL: Failed to import MCP SDK from 'mcp' package ({e_mcp}). This integration will not work without the SDK.")
-
-    # --- フォールバック用のモック (いずれ削除) ---
-    class MockClientSession: # ClientSessionのモック
-        def __init__(self, read_stream, write_stream, sampling_callback=None):
-            self.name = "mock-session" # 仮
-            logger.info(f"MockClientSession created for {self.name}")
-
-        async def initialize(self):
-            logger.info(f"MockClientSession {self.name}: Initialized.")
-            await asyncio.sleep(0.01)
-
-        async def list_tools(self) -> List[Dict[str, Any]]: # listTools -> list_tools, 戻り値もSDKに合わせる
-            logger.info(f"MockClientSession {self.name}: list_tools called")
-            # filesystemサーバーのモックの場合のみツールを返す
-            if hasattr(self, '_server_name_for_mock') and self._server_name_for_mock == "filesystem":
-                 return [{"name": "read_file", "description": "Reads a file (mock_session)"}]
-            return []
-
-        async def list_resources(self) -> List[Dict[str, Any]]:
-            logger.info(f"MockClientSession {self.name}: list_resources called")
-            return []
-
-        async def call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
-            logger.info(f"MockClientSession {self.name}: call_tool '{tool_name}' with args: {arguments}")
-            if hasattr(self, '_server_name_for_mock') and self._server_name_for_mock == "filesystem" and \
-               tool_name == "read_file" and "path" in arguments:
-                return {"content": [{"type": "text", "text": f"Mock content of {arguments['path']} from MockClientSession"}]}
-            return {"error": f"Mock tool '{tool_name}' failed or not found in MockClientSession"}
-
-        async def close(self):
-            logger.info(f"MockClientSession {self.name}: Closed.")
-            await asyncio.sleep(0.01)
-
-    # StdioServerParameters のモック (もし必要なら)
-    class MockStdioServerParameters:
+    print(f"Warning: Failed to import MCP SDK from 'mcp' package ({e_mcp}). Subprocess test will proceed, but full functionality requires SDK.")
+    # モック定義は subprocess テスト中は不要なので削除またはコメントアウト
+    # class ClientSession: pass
+    class StdioServerParameters: # type: ignore
         def __init__(self, command: str, args: List[str], env: Optional[Dict[str, str]] = None):
             self.command = command
             self.args = args
             self.env = env if env is not None else {}
+    # Tool = Dict[str, Any]
+    # Resource = Dict[str, Any]
 
-    # stdio_client のモック (非同期コンテキストマネージャ)
-    class MockStdioClientContextManager:
-        def __init__(self, params: MockStdioServerParameters):
-            self._params = params
-            logger.info(f"MockStdioClientContextManager initialized for command: {params.command}")
-
-        async def __aenter__(self):
-            logger.info("MockStdioClientContextManager: __aenter__ called. Simulating stream acquisition.")
-            # ダミーのストリームを返す (実際には transport が持つべきもの)
-            # ClientSessionのモックがストリームを直接使わないので、Noneでも良いかもしれない
-            return (None, None) # (read_stream, write_stream)
-
-        async def __aexit__(self, exc_type, exc_val, exc_tb):
-            logger.info("MockStdioClientContextManager: __aexit__ called. Simulating process termination.")
-
-    if not MCP_SDK_AVAILABLE: # グローバル名をモックで上書き
-        ClientSession = MockClientSession # type: ignore
-        StdioServerParameters = MockStdioServerParameters # type: ignore
-        stdio_client = MockStdioClientContextManager # type: ignore
-        Tool = Dict[str, Any]
-        Resource = Dict[str, Any]
-        # ToolCallResult は call_tool の戻り値なので Dict[str, Any] でよい
-
-# --- ここまでMCP SDKインポート & モック定義 ---
 
 import logging
 logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
 
 class MCPClientManager:
     def __init__(self, config_manager: Optional[Any] = None):
-        self.sessions: Dict[str, ClientSession] = {} # Client -> ClientSession
-        self.active_stdio_contexts: Dict[str, Any] = {} # 起動したstdio_clientのコンテキストを保持
-        self.available_tools: Dict[str, Tool] = {}
-        self.available_resources: Dict[str, Resource] = {}
+        # self.sessions: Dict[str, ClientSession] = {} # subprocess直接利用時はClientSessionはまだ作らない
+        self.server_processes: Dict[str, subprocess.Popen] = {} # 起動したサブプロセスを保持
+        self.available_tools: Dict[str, Any] = {} # Anyの代わりにTool型を使いたい
+        self.available_resources: Dict[str, Any] = {} # Anyの代わりにResource型を使いたい
         self.config_manager = config_manager
 
+    def _resolve_server_script_path(self, command: str, raw_args: List[str]) -> List[str]:
+        processed_args = []
+        if command == "python" and raw_args:
+            script_path_arg = raw_args[0]
+            try:
+                project_root = Path(__file__).resolve().parent
+                if script_path_arg.startswith('./'):
+                    script_path_arg = script_path_arg[2:]
+                elif script_path_arg.startswith('.\\'):
+                    script_path_arg = script_path_arg[2:]
+                absolute_script_path = (project_root / script_path_arg).resolve()
+                if absolute_script_path.is_file():
+                    processed_args.append(str(absolute_script_path))
+                    processed_args.extend(raw_args[1:])
+                    logger.info(f"Resolved server script path to: {absolute_script_path}")
+                else:
+                    logger.warning(f"Server script path '{script_path_arg}' (resolved to '{absolute_script_path}') does not exist or is not a file. Using raw args: {raw_args}")
+                    processed_args = list(raw_args)
+            except Exception as path_e:
+                logger.error(f"Error resolving server script path '{script_path_arg}': {path_e}. Using raw args: {raw_args}", exc_info=True)
+                processed_args = list(raw_args)
+        else:
+            processed_args = list(raw_args)
+        return processed_args
+
     async def connect_to_server(self, server_name: str, server_config: Dict[str, Any]) -> None:
-        if server_name in self.sessions:
-            logger.info(f"MCPサーバー \"{server_name}\" のセッションは既に確立済みです。")
+        if server_name in self.server_processes and self.server_processes[server_name].poll() is None:
+            logger.info(f"MCPサーバー \"{server_name}\" のプロセスは既に起動済みか、起動試行中です。")
             return
 
-        if not MCP_SDK_AVAILABLE:
-            logger.error("MCP SDK is not available. Cannot connect to server.")
-            # モックを使う場合でも、モックのstdio_clientが非同期コンテキストマネージャを返すように修正したので、
-            # 以下はSDKがある場合とほぼ同じロジックで進められるはず。
-            # ただし、MockClientSessionに _server_name_for_mock を設定する必要がある。
-            # この部分は、SDKが本当にない場合は機能しないことを明確にするため、returnしてもよい。
-            # return # SDKがなければ接続処理を中断
-
         try:
-            logger.info(f"MCPサーバー \"{server_name}\" への接続を開始します。設定: {server_config}")
-
             command = server_config.get("command")
             raw_args = server_config.get("args", [])
-            env = server_config.get("env", {})
+            env_config = server_config.get("env", {}).copy()
 
-            processed_args = []
-            if command == "python" and raw_args:
-                script_path_arg = raw_args[0]
-                try:
-                    project_root = Path(__file__).resolve().parent # mcp_client.py がプロジェクトルート直下にある想定
+            processed_args = self._resolve_server_script_path(command, raw_args)
 
-                    # './' や '.\' で始まっている場合、それを除去 (os.path.normpathでも良いが、確実性のため)
-                    if script_path_arg.startswith('./'):
-                        script_path_arg = script_path_arg[2:]
-                    elif script_path_arg.startswith('.\\'):
-                        script_path_arg = script_path_arg[2:]
+            if not command or not processed_args:
+                raise ValueError(f"サーバー '{server_name}' のコマンドまたは引数が正しく設定されていません。")
 
-                    absolute_script_path = (project_root / script_path_arg).resolve() # resolve()で正規化と存在確認(シンボリックリンク等)
+            env_for_subprocess = os.environ.copy() # 現在の環境変数を引き継ぐ
+            env_for_subprocess.update(env_config) # 設定ファイルからの環境変数を上書き/追加
+            env_for_subprocess["PYTHONUNBUFFERED"] = "1" # バッファリング無効を強制
 
-                    if absolute_script_path.is_file(): # resolve()後にis_file()で実ファイルか確認
-                        processed_args.append(str(absolute_script_path))
-                        processed_args.extend(raw_args[1:])
-                        logger.info(f"Resolved server script path to: {absolute_script_path}")
-                    else:
-                        logger.warning(f"Server script path {script_path_arg} (resolved to {absolute_script_path}) does not exist or is not a file. Using raw args: {raw_args}")
-                        processed_args = list(raw_args)
-                except Exception as path_e:
-                    logger.error(f"Error resolving server script path '{script_path_arg}': {path_e}. Using raw args: {raw_args}", exc_info=True)
-                    processed_args = list(raw_args)
+            # PYTHONPATHにカレントディレクトリ（プロジェクトルート想定）を追加してみる
+            # これにより、サブプロセスがモジュールを見つけやすくなるかもしれない
+            project_root_str = str(Path(__file__).resolve().parent)
+            existing_pythonpath = env_for_subprocess.get("PYTHONPATH", "")
+            if project_root_str not in existing_pythonpath.split(os.pathsep):
+                env_for_subprocess["PYTHONPATH"] = f"{project_root_str}{os.pathsep}{existing_pythonpath}".strip(os.pathsep)
+            logger.info(f"Effective PYTHONPATH for subprocess: {env_for_subprocess.get('PYTHONPATH')}")
+
+
+            logger.info(f"Attempting to launch server '{server_name}' via subprocess.Popen:")
+            logger.info(f"  Command: {command}")
+            logger.info(f"  Args: {processed_args}")
+            # Popenのcwdは、スクリプトパスが絶対パスなら不要かもしれないが、念のため設定
+            # スクリプトが自身の位置からの相対パスで何かを読み込む場合に影響する
+            script_dir = Path(processed_args[0]).parent if processed_args else Path(__file__).resolve().parent
+            logger.info(f"  CWD (for Popen): {script_dir}")
+            logger.info(f"  Env (selected items for log): PYTHONUNBUFFERED={env_for_subprocess.get('PYTHONUNBUFFERED')}, PYTHONPATH={env_for_subprocess.get('PYTHONPATH')}")
+
+
+            # subprocess.PIPE を使うと、communicate() で待つか、非同期で読み出す必要がある
+            # 今回はダミースクリプトがファイルにログを出すので、stdout/stderrはキャプチャせずOSデフォルトへ
+            process = subprocess.Popen(
+                [command] + processed_args,
+                text=True,
+                encoding='utf-8',
+                env=env_for_subprocess,
+                cwd=script_dir, # スクリプトがあるディレクトリをCWDに
+                # stdin=subprocess.DEVNULL, # stdinは使わないので閉じておく (stdio_clientは接続する)
+                # stdout=subprocess.PIPE, # デバッグ用にキャプチャする場合
+                # stderr=subprocess.PIPE  # デバッグ用にキャプチャする場合
+            )
+            self.server_processes[server_name] = process
+
+            logger.info(f"Subprocess for '{server_name}' launched with PID: {process.pid}. Waiting a few seconds for it to initialize and create log files...")
+            await asyncio.sleep(5) # 5秒待機
+
+            logger.info(f"Subprocess test for '{server_name}' finished waiting. Please check for 'logs/dummy_server_startup.log' and 'logs/dummy_server_flag.txt'.")
+
+            retcode = process.poll()
+            if retcode is not None:
+                logger.warning(f"Subprocess for '{server_name}' exited early with code: {retcode}")
+                # もしstdout/stderrをPIPEにしていればここで読み出せる
+                # stdout_data, stderr_data = process.communicate(timeout=1)
+                # logger.info(f"Subprocess stdout: {stdout_data}")
+                # logger.error(f"Subprocess stderr: {stderr_data}")
             else:
-                processed_args = list(raw_args)
-
-            if not command:
-                raise ValueError(f"サーバー '{server_name}' の 'command' 設定がありません。")
-
-            server_params = StdioServerParameters(command=command, args=processed_args, env=env)
-
-            # stdio_client を非同期コンテキストマネージャとして使用
-            # self.active_stdio_contexts にコンテキストを保存し、shutdownで解放する
-            # stdio_client は関数なので、呼び出し結果がコンテキストマネージャになる
-            stdio_cm = stdio_client(server_params)
-            self.active_stdio_contexts[server_name] = stdio_cm # 後で __aexit__ するために保持
-            read_stream, write_stream = await stdio_cm.__aenter__() # 手動でenter
-
-            # ClientSession の作成と初期化
-            # sampling_callback はLLMがクライアント側で動作する場合に使うもの。今回は不要。
-            session = ClientSession(read_stream, write_stream)
-            # SDKが利用可能な場合は、sessionがMockClientSessionであることはないので、以下の分岐は不要
-            # if not MCP_SDK_AVAILABLE and isinstance(session, MockClientSession):
-            #     session._server_name_for_mock = server_name
-
-
-            await session.initialize() # MCPハンドシェイク
-
-            await self._discover_server_capabilities(session, server_name)
-
-            self.sessions[server_name] = session
-            logger.info(f"MCPサーバー \"{server_name}\" とのセッションを正常に確立しました。")
+                logger.info(f"Subprocess for '{server_name}' is still running.")
 
         except Exception as e:
-            logger.error(f"MCPサーバー \"{server_name}\" への接続エラー: {e}", exc_info=True)
-            if server_name in self.active_stdio_contexts: # エラー発生時にもexitを試みる
-                try:
-                    await self.active_stdio_contexts[server_name].__aexit__(type(e), e, e.__traceback__)
-                except Exception as e_exit:
-                    logger.error(f"Error during __aexit__ for {server_name} after connection error: {e_exit}")
-                del self.active_stdio_contexts[server_name]
+            logger.error(f"Error launching or interacting with subprocess for server '{server_name}': {e}", exc_info=True)
 
-
-    async def _discover_server_capabilities(self, session: ClientSession, server_name: str) -> None:
-        try:
-            tools_response = await session.list_tools() # listTools -> list_tools
-            # tools_response の形式はSDKによる。List[Tool] を期待。
-            # Tool 型もSDKで定義されているはず。ここでは Dict[str, Any] と仮定。
-            if tools_response: # tools_response が None でないかつ空でないリストであることを確認
-                for tool_data in tools_response: # list_tools() がリストを返すと仮定
-                    # tool_data が辞書であることを期待 (Tool型が辞書的な場合)
-                    if isinstance(tool_data, dict) and 'name' in tool_data:
-                        tool_name = tool_data['name']
-                        tool_id = f"{server_name}:{tool_name}"
-                        self.available_tools[tool_id] = {
-                            "serverName": server_name,
-                            "name": tool_name, # 明示的にnameを再度格納
-                            **tool_data # tool_data の他のキー (description, inputSchemaなど) も展開
-                        }
-                        logger.info(f"ツール発見: {tool_id} ({tool_data.get('description')})")
-                    elif hasattr(tool_data, 'name'): # オブジェクトの場合
-                        tool_name = tool_data.name
-                        tool_id = f"{server_name}:{tool_name}"
-                        # Toolオブジェクトをそのまま保存するか、辞書に変換するか検討
-                        # ここでは辞書に変換する例
-                        self.available_tools[tool_id] = {
-                            "serverName": server_name,
-                            "name": tool_name,
-                            "description": getattr(tool_data, 'description', None),
-                            "inputSchema": getattr(tool_data, 'inputSchema', None),
-                             # 他の属性も同様に
-                        }
-                        logger.info(f"ツール発見: {tool_id} ({getattr(tool_data, 'description', '')})")
-
-            else:
-                logger.info(f"サーバー \"{server_name}\" からツール情報は提供されませんでした (空またはNone)。")
-
-            # resources についても同様 (session.list_resources())
-            resources_response = await session.list_resources()
-            if resources_response:
-                for res_data in resources_response:
-                    if isinstance(res_data, dict) and 'uri' in res_data:
-                        res_uri = res_data['uri']
-                        res_id = f"{server_name}:{res_uri}"
-                        self.available_resources[res_id] = {
-                            "serverName": server_name,
-                            "uri": res_uri,
-                            **res_data
-                        }
-                        logger.info(f"リソース発見: {res_id} ({res_data.get('description')})")
-                    elif hasattr(res_data, 'uri'):
-                        res_uri = res_data.uri
-                        res_id = f"{server_name}:{res_uri}"
-                        self.available_resources[res_id] = {
-                            "serverName": server_name,
-                            "uri": res_uri,
-                            "description": getattr(res_data, 'description', None),
-                        }
-                        logger.info(f"リソース発見: {res_id} ({getattr(res_data, 'description', '')})")
-            else:
-                logger.info(f"サーバー \"{server_name}\" からリソース情報は提供されませんでした (空またはNone)。")
-
-        except Exception as e:
-            logger.error(f"サーバー \"{server_name}\" の機能発見中にエラー: {e}", exc_info=True)
+    async def _discover_server_capabilities(self, session: Any, server_name: str) -> None: # sessionの型をAnyに
+        # このテスト中は呼び出されない想定
+        logger.info("_discover_server_capabilities called, but not functional in subprocess test mode.")
+        pass
 
     async def execute_tool(self, tool_id: str, parameters: Dict[str, Any]) -> Dict[str, Any]:
-        if tool_id not in self.available_tools:
-            logger.error(f"ツール \"{tool_id}\" が見つかりません。利用可能なツール: {list(self.available_tools.keys())}")
-            raise ValueError(f"ツール \"{tool_id}\" が見つかりません。")
+        # このテスト中は呼び出されない想定
+        logger.info(f"execute_tool '{tool_id}' called, but not functional in subprocess test mode.")
+        return {"success": False, "error": "Not functional in subprocess test mode"}
 
-        tool_info = self.available_tools[tool_id]
-        server_name = tool_info["serverName"]
-        original_tool_name = tool_info["name"] # サーバー側でのツール名
-
-        session = self.sessions.get(server_name)
-        if not session:
-            logger.error(f"ツール \"{tool_id}\" のサーバー \"{server_name}\" のセッションが接続されていません。")
-            raise ConnectionError(f"サーバー \"{server_name}\" のセッションが接続されていません。")
-
-        try:
-            logger.info(f"ツール \"{original_tool_name}\" (ID: {tool_id}) をパラメータ {parameters} で実行します。")
-            # call_tool の引数は (tool_name: str, arguments: dict)
-            result = await session.call_tool(tool_name=original_tool_name, arguments=parameters)
-            # result の形式はSDKによる。mcp-integration-guide.md では {"content": ...} や {"error": ...} を想定。
-            logger.info(f"ツール \"{tool_id}\" の実行結果 (RAW): {result}") # 生の結果をログに出力
-            return self._process_tool_result(result)
-
-        except Exception as e:
-            logger.error(f"ツール \"{tool_id}\" の実行エラー: {e}", exc_info=True)
-            raise RuntimeError(f"ツール \"{tool_id}\" の実行に失敗しました: {e}")
-
-    def _process_tool_result(self, result: Any) -> Dict[str, Any]: # resultの型はSDKのcall_toolの戻り値による
-        # SDKの call_tool が返すオブジェクトの構造に合わせて調整が必要
-        # ガイドでは result.content や result.error を見ていた
-        # ここでは、result が辞書であることを期待し、キー 'content' または 'error' を持つと仮定する
-        # 実際のSDKでは、resultが特定のクラスインスタンスである可能性が高い
-
-        if isinstance(result, dict):
-            if "content" in result:
-                # content が [{"type": "text", "text": "..."}] のようなリスト形式か、
-                # 単純な文字列やオブジェクトか、SDK仕様による。
-                # ガイドの FileSystemMCPServer は content: [{ type: 'text', text: content }] を返していた。
-                # その場合、クライアント側でそれをどう受け取るか。
-                # ここでは、ガイドのクライアント側 processToolResult に合わせる。
-                content_data = result.get("content")
-                # content_data がリストで、最初の要素が辞書で "text" キーを持つ場合、その値を取得
-                processed_content = content_data
-                if isinstance(content_data, list) and len(content_data) > 0 and \
-                   isinstance(content_data[0], dict) and "text" in content_data[0]:
-                    processed_content = content_data[0]["text"]
-
-                return {
-                    "success": True,
-                    "data": processed_content, # もし TextContent オブジェクトなら .text などでアクセス
-                    "metadata": result.get("metadata", {})
-                }
-            elif "error" in result:
-                logger.error(f"ツール実行エラー (サーバーからのエラー): {result['error']}")
-                return {
-                    "success": False,
-                    "error": str(result['error']),
-                    "details": result.get("details")
-                }
-
-        # 上記に当てはまらない場合、result が直接的なデータか、あるいは未知の形式
-        # もし result が TextContent のようなオブジェクトなら、その .text 属性などを取得する
-        if hasattr(result, 'text') and isinstance(getattr(result, 'text'), str) : # 例: TextContent オブジェクト
-             return {"success": True, "data": getattr(result, 'text')}
-        if hasattr(result, 'result') : # 例: {"result": value} のようなプリミティブラッパー
-             return {"success": True, "data": getattr(result, 'result')}
-
-
-        logger.warning(f"予期しないツール結果形式、またはエラー情報なし: {result}")
-        # そのまま返すか、エラーとして扱うか。
-        # ここでは成功としてそのままデータを渡すが、より厳密なエラー処理が必要かもしれない。
-        return {"success": True, "data": result}
-
+    def _process_tool_result(self, result: Any) -> Dict[str, Any]:
+        # このテスト中は呼び出されない想定
+        return {}
 
     async def initialize_servers_from_config(self) -> None:
         if not self.config_manager:
             logger.warning("ConfigManagerが設定されていません。MCPサーバーの初期化をスキップします。")
             return
-
         mcp_config = self.config_manager.get_mcp_settings()
         if not mcp_config or "servers" not in mcp_config:
             logger.info("MCPサーバーの設定が見つかりません。")
             return
-
         for server_name, server_settings in mcp_config["servers"].items():
             if isinstance(server_settings, dict) and server_settings.get("enabled", True):
                 try:
+                    # connect_to_server は非同期なので create_task で並行実行も可能だが、
+                    # ここでは順次実行（デバッグしやすいため）
                     await self.connect_to_server(server_name, server_settings)
                 except Exception as e:
-                    logger.error(f"サーバー \"{server_name}\" の初期化中にエラーが発生しました: {e}", exc_info=True)
+                    logger.error(f"サーバー \"{server_name}\" の初期化(connect_to_server呼び出し)中にエラー: {e}", exc_info=True)
             else:
                 logger.info(f"サーバー \"{server_name}\" は無効化されているか、設定が不正です。スキップします。")
 
     async def shutdown(self) -> None:
-        logger.info("全てのMCPクライアントセッションとプロセスをシャットダウンします...")
-        for server_name, session in list(self.sessions.items()): # list()でコピーしてイテレート
-            try:
-                await session.close()
-                logger.info(f"サーバー \"{server_name}\" とのセッションを正常にクローズしました。")
-            except Exception as e:
-                logger.error(f"サーバー \"{server_name}\" とのセッションクローズ中にエラー: {e}", exc_info=True)
-            finally:
-                del self.sessions[server_name]
-
-        for server_name, stdio_cm_instance in list(self.active_stdio_contexts.items()):
-            try:
-                # 非同期コンテキストマネージャの __aexit__ を呼び出す
-                await stdio_cm_instance.__aexit__(None, None, None)
-                logger.info(f"サーバー \"{server_name}\" のstdioプロセスを正常に終了しました。")
-            except Exception as e:
-                logger.error(f"サーバー \"{server_name}\" のstdioプロセス終了中にエラー: {e}", exc_info=True)
-            finally:
-                del self.active_stdio_contexts[server_name]
+        logger.info("全てのMCPサーバープロセスをシャットダウンします...")
+        for server_name, process in list(self.server_processes.items()):
+            if process.poll() is None: # プロセスがまだ実行中なら
+                logger.info(f"Terminating server process '{server_name}' (PID: {process.pid})...")
+                process.terminate() # SIGTERM を送信
+                try:
+                    process.wait(timeout=5) # 最大5秒待つ
+                    logger.info(f"Server process '{server_name}' terminated with code {process.returncode}.")
+                except subprocess.TimeoutExpired:
+                    logger.warning(f"Server process '{server_name}' did not terminate in time, killing...")
+                    process.kill() # 強制終了
+                    logger.info(f"Server process '{server_name}' killed.")
+                except Exception as e:
+                    logger.error(f"Error during server process '{server_name}' shutdown: {e}", exc_info=True)
+            else:
+                logger.info(f"Server process '{server_name}' already exited with code {process.returncode}.")
+            del self.server_processes[server_name]
 
         self.available_tools.clear()
         self.available_resources.clear()
         logger.info("MCPクライアントのシャットダウンが完了しました。")
 
-
 # (main_test はSDKの具体的なAPIが判明してから書き直す必要があるため一旦コメントアウト)
-# async def main_test():
-#     # ...
-#     pass
-
-# if __name__ == "__main__":
-#     # loop = asyncio.get_event_loop()
-#     # try:
-#     #     loop.run_until_complete(main_test())
-#     # finally:
-#     #     loop.close()
-#     pass

--- a/mcp_servers/file_system_server.py
+++ b/mcp_servers/file_system_server.py
@@ -1,181 +1,48 @@
-import asyncio
-import json
-import os
-import sys # sysモジュールをインポート
 from pathlib import Path
-from typing import List, Dict, Any, TypedDict, Optional # Optional をインポート
+import datetime
+import os
+import sys # sysをインポート
 
-# --- 専用ファイルロガー設定 ---
+# このスクリプト自身のログファイルを設定 (mcp_client.py側のロガーとは独立)
 LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
 LOG_DIR.mkdir(exist_ok=True)
-SERVER_LOG_FILE = LOG_DIR / "filesystem_server.log"
+SERVER_DUMMY_LOG_FILE = LOG_DIR / "dummy_server_startup.log"
 
-server_logger = logging.getLogger("FileSystemMCPServerProcess") # メインプロセスと異なるロガー名
-server_logger.setLevel(logging.DEBUG)
-# ログが重複して出力されるのを防ぐため、既存のハンドラをクリア (もしあれば)
-if server_logger.hasHandlers():
-    server_logger.handlers.clear()
-fh = logging.FileHandler(SERVER_LOG_FILE, mode='w', encoding='utf-8')
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-fh.setFormatter(formatter)
-server_logger.addHandler(fh)
-server_logger.propagate = False # 親ロガーへの伝播を防ぐ
+# 簡単なファイルロギング
+def log_to_file(message):
+    timestamp = datetime.datetime.now().isoformat()
+    with open(SERVER_DUMMY_LOG_FILE, "a", encoding="utf-8") as f:
+        f.write(f"{timestamp} - {message}\n")
 
-server_logger.info("FileSystemMCPServer process started.")
-server_logger.info(f"Current working directory: {os.getcwd()}")
-server_logger.info(f"Python executable: {sys.executable}")
-server_logger.info(f"sys.path: {sys.path}")
-# --- ロガー設定ここまで ---
-
-
-# MCP SDK のインポート
-try:
-    from mcp.server.fastmcp import FastMCP
-    from mcp.types import TextContent # TextContent をインポート試行
-    MCP_SDK_SERVER_AVAILABLE = True
-    server_logger.info("Successfully imported MCP SDK server classes (FastMCP, TextContent).")
-except ImportError as e:
-    MCP_SDK_SERVER_AVAILABLE = False
-    server_logger.error(f"Failed to import MCP SDK for Server (FastMCP or TextContent) ({e}). Mocking will be limited.", exc_info=True)
-    class FastMCP: # type: ignore
-        def __init__(self, name: str, version: str = "0.1.0", stateless_http: bool = False):
-            self.name = name
-            self.version = version
-            server_logger.warning("Using Mock FastMCP. Server will not be fully functional.")
-        def tool(self, name: Optional[str] = None, description: Optional[str] = None, title: Optional[str] = None):
-            def decorator(func):
-                server_logger.info(f"Mock FastMCP: Tool '{name or func.__name__}' registered (mock).")
-                return func
-            return decorator
-        def run(self):
-            server_logger.info("Mock FastMCP: run() called (mock, does nothing).")
-
-    class TextContent: # type: ignore
-         def __init__(self, type:str, text:str):
-             self.type = type
-             self.text = text
-             server_logger.info(f"Mock TextContent created with text: {text[:30]}...")
-
-
-# ロギング設定 (メインのlogger、これはFastMCP内部などで使われる可能性を考慮して残す)
-import logging # logging は既に上でインポート済みだが、スタイルとしてここに書くことも
-logger = logging.getLogger(__name__) # このモジュール用の標準ロガー
-# if __name__ == '__main__': # このファイルが直接実行される場合のみ基本設定
-#    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-# -> 基本的なbasicConfigはメインアプリ(main.pyやlauncher.py)で行う想定なのでコメントアウト
-# server_logger がファイル出力するので、こちらのloggerはコンソール出力のまま(もしあれば)
-
-# --- グローバルなFastMCPインスタンス ---
-mcp_server = FastMCP(name="filesystem-server", version="1.0.1")
-server_logger.info(f"FastMCP instance created: Name='{mcp_server.name}'") # versionはFastMCPが持つか不明なのでログからは削除
-
-# --- ベースディレクトリ設定 ---
-BASE_DIR = Path(__file__).resolve().parent.parent
-server_logger.info(f"FileSystemMCPServer (FastMCP) base directory set to: {BASE_DIR}")
-
-
-# --- 型定義 (ツールの出力用) ---
-# mcp-integration-guide.md のサーバー側 handleReadFile の戻り値形式に合わせる
-# {"content": [{"type": "text", "text": content}]}
-# これを FastMCP で実現するには、ツールが List[TextContent] を返すのが適切そう
-# あるいは、ツールが Dict[str, List[Dict[str,str]]] を返し、クライアントがそれをそのまま使うか。
-# GitHub READMEの "Structured Output" によると、PydanticモデルやTypedDictが使える。
-# ここでは TypedDict を使って、期待されるJSON構造に合うようにしてみる。
-class FileContentItem(TypedDict):
-    type: str
-    text: str
-
-class ReadFileToolOutput(TypedDict):
-    content: List[FileContentItem]
-
-
-# --- ツール定義 ---
-@mcp_server.tool(
-    name="read_file", # ツール名を明示
-    description="指定されたパスのファイルの内容を読み取ります。パスはプロジェクトルートからの相対パスです。",
-    title="ファイル読み取り" # オプションでタイトルも
-)
-async def tool_read_file(path: str) -> ReadFileToolOutput: # 戻り値の型アノテーション
-    """
-    ファイルの内容を読み取り、MCPが期待する形式で返します。
-    """
-    logger.info(f"FastMCP tool 'read_file' called with path: {path}")
-
-    if not isinstance(path, str):
-        # FastMCPが型チェックしてくれるはずだが念のため
-        logger.error(f"Path argument is not a string: {type(path)}")
-        # エラーの返し方はFastMCPの作法に合わせる。通常は例外をraiseする。
-        raise TypeError("Path must be a string.")
-
-    file_path_str = path
-
-    try:
-        # セキュリティ: パストラバーサル攻撃を防ぐ
-        normalized_user_path = os.path.normpath(file_path_str)
-        if normalized_user_path.startswith("..") or os.path.isabs(normalized_user_path) or \
-           normalized_user_path.startswith("/") or normalized_user_path.startswith("\\"):
-            logger.warning(f"Attempted unauthorized path access (normalized): {normalized_user_path}")
-            raise PermissionError("不正なパス形式です。絶対パスや親ディレクトリへの移動、ルートからのパス指定は許可されていません。")
-
-        absolute_path = BASE_DIR.joinpath(normalized_user_path).resolve()
-
-        if not str(absolute_path).startswith(str(BASE_DIR.resolve())):
-            logger.warning(f"Attempted directory traversal. Base: {BASE_DIR}, Target: {absolute_path}")
-            raise PermissionError(f"指定されたパス '{file_path_str}' へのアクセスは許可されていません。")
-
-        if not absolute_path.is_file():
-            logger.error(f"File not found at resolved path: {absolute_path}")
-            raise FileNotFoundError(f"ファイル '{absolute_path}' が見つかりません。")
-
-        logger.info(f"Reading file: {absolute_path}")
-        # 大容量ファイルを扱う場合は非同期ファイルI/O (例: aiofiles) を検討
-        with open(absolute_path, 'r', encoding='utf-8') as f:
-            content_text = f.read()
-
-        # mcp-integration-guide.md のレスポンス形式に合わせる
-        output: ReadFileToolOutput = {
-            "content": [
-                {"type": "text", "text": content_text}
-            ]
-        }
-        logger.info(f"File '{path}' read successfully. Content length: {len(content_text)}")
-        return output
-
-    except PermissionError as e:
-        logger.error(f"Permission denied for path '{file_path_str}': {e}")
-        # FastMCPは例外をキャッチしてエラーレスポンスに変換するはず
-        raise # 再raiseしてFastMCPに処理させる
-    except FileNotFoundError as e:
-        logger.error(f"File not found at path '{file_path_str}': {e}")
-        raise
-    except Exception as e:
-        logger.error(f"Error reading file '{file_path_str}': {e}", exc_info=True)
-        # 包括的なエラーもFastMCPが処理する
-        raise ValueError(f"ファイル読み取り中に予期せぬエラーが発生しました: {e}")
-
-
-# --- サーバー起動 ---
 if __name__ == "__main__":
-    # このファイルを直接 `python file_system_server.py` で実行するとサーバーが起動する
-    if not MCP_SDK_SERVER_AVAILABLE:
-        logger.critical("MCP SDK (Server) is not available. FileSystemMCPServer cannot start properly.")
-        logger.info("This instance will use a mock FastMCP and will not function as a real MCP server.")
-        # モックのrun()はブロッキングしないかもしれないので、メッセージを出して終了
-        mcp_server.run() # モックのrunを呼ぶ（何もしない想定）
-        logger.info("Mock FastMCP run finished. Exiting as SDK is not available.")
-        exit()
+    log_to_file("Dummy server process started.")
+    log_to_file(f"Current working directory: {os.getcwd()}")
+    log_to_file(f"Python executable: {sys.executable}")
+    log_to_file(f"sys.path: {str(sys.path)}") # sys.pathはリストなのでstr()で囲む
+    log_to_file(f"Script __file__: {__file__}")
+    log_to_file(f"Script absolute path: {str(Path(__file__).resolve())}")
 
+    # 標準出力に何か書く (クライアントがこれを読めるかテストのため)
+    print("Dummy server: Standard output message.", flush=True)
+
+    # 標準エラー出力にも何か書く
+    sys.stderr.write("Dummy server: Standard error message.\n")
+    sys.stderr.flush()
+
+    log_to_file("Dummy server attempting to create a flag file.")
+
+    # 起動した証として別のファイルを作成する
+    SERVER_STARTED_FLAG_FILE = LOG_DIR / "dummy_server_flag.txt"
     try:
-        logger.info(f"Starting FileSystemMCPServer (FastMCP) '{mcp_server.name}'...")
-        # FastMCP.run() がブロッキングしてサーバーを起動するはず
-        mcp_server.run()
-        logger.info("FileSystemMCPServer (FastMCP) stopped.") # 通常はここまで到達しない
-    except KeyboardInterrupt:
-        logger.info("FileSystemMCPServer (FastMCP) shutting down via KeyboardInterrupt...")
-    except RuntimeError as e:
-        if "Already running asyncio" in str(e): # このエラーは直接実行では起きにくいはずだが念のため
-            logger.error(f"Failed to start server: {e}. This might happen if the script is run in an environment that already has an asyncio loop (e.g. Jupyter). Try running as a standalone script.")
-        else:
-            logger.error(f"An unexpected RuntimeError occurred: {e}", exc_info=True)
+        with open(SERVER_STARTED_FLAG_FILE, "w", encoding="utf-8") as f:
+            f.write(f"Dummy FileSystemMCPServer started at: {datetime.datetime.now().isoformat()}\n")
+            f.write(f"This file confirms the dummy server process was launched successfully.\n")
+        log_to_file(f"Successfully created flag file: {SERVER_STARTED_FLAG_FILE}")
     except Exception as e:
-        logger.error(f"An error occurred while running FileSystemMCPServer (FastMCP): {e}", exc_info=True)
+        log_to_file(f"ERROR creating flag file: {e}")
+
+    log_to_file("Dummy server process finished its main execution block.")
+    # 通常、MCPサーバーはここでリクエストを待ち受けるループに入るが、
+    # このダミースクリプトはすぐ終了する。
+    # クライアント側がプロセス終了をどう扱うかによっては、
+    # time.sleep(数秒) を入れても良いかもしれない。


### PR DESCRIPTION
Modified `MCPClientManager.connect_to_server` to use Python's standard `subprocess.Popen` instead of the MCP SDK's `stdio_client`. This is a temporary debugging step to isolate issues with subprocess creation and basic execution of the (dummy) server script, by checking if it can create its log files when launched this way. This bypasses the SDK's stdio handling for now.